### PR TITLE
Cassandra seeding implementation

### DIFF
--- a/dataGenerator.js
+++ b/dataGenerator.js
@@ -19,6 +19,8 @@ if (process.argv[4] == 'fs') {
   saveDataTo = 'fs';
 } else if (process.argv[4] == 'cass') {
   saveDataTo = 'cass';
+  entriesPerBatch = 5;
+  //TODO: refactor entire 'entriesPerBatch' handling process--for testing, it was convenient to supply this value as an argument. But now that I know the optimal batch sizes for fs vs. pg vs. cassandra at varying entry quantities, it makes more sense to calculate the optimal batch size in the code rather than ask the user to supply it
 }
 
 // handle large data sets for postgres, where query bound to params list caps out at ~30k params
@@ -72,13 +74,13 @@ const generateData = async () => {
           console.log(`file ${fileNameSerial} written!`);
         } else if (saveDataTo == 'cass') {
           const response = await cass.insertData(dataList);
-          console.log(`batch ${fileNameSerial} complete!: `, response);
         }
 
         dataList = [];
       }
     }
     pgdb.endPool();
+    cass.shutdown();
     console.timeEnd('duration data gen and seed');
 }
 

--- a/dataGenerator.js
+++ b/dataGenerator.js
@@ -2,6 +2,7 @@ const faker = require('faker');
 const fs = require('fs');
 const loremHipsum = require('lorem-hipsum');
 const pgdb = require('./db/index.js');
+const cass = require('./db/indexCass.js');
 
 console.time('duration data gen and seed');
 
@@ -70,7 +71,8 @@ const generateData = async () => {
           fs.writeFileSync(`./data/testData${fileNameSerial}.json`, JSON.stringify(dataList));
           console.log(`file ${fileNameSerial} written!`);
         } else if (saveDataTo == 'cass') {
-          //TODO: write cassandra db insert
+          const response = await cass.insertData(dataList);
+          console.log(`batch ${fileNameSerial} complete!: `, response);
         }
 
         dataList = [];

--- a/db/indexCass.js
+++ b/db/indexCass.js
@@ -6,6 +6,10 @@ const client = new cassandra.Client({
   localDataCenter: 'datacenter1'
 })
 
+module.exports.shutdown = () => {
+  client.shutdown();
+}
+
 module.exports.insertData = async (dataArr) => {
   try {
     const queries = dataArr.map((entry) => {

--- a/db/indexCass.js
+++ b/db/indexCass.js
@@ -5,7 +5,7 @@ const client = new cassandra.Client({
   keyspace: 'testyboi'
 })
 
-const insertData = async (dataArr) => {
+module.exports.insertData = async (dataArr) => {
   try {
     const queries = dataArr.map((entry) => {
       return {

--- a/db/indexCass.js
+++ b/db/indexCass.js
@@ -1,0 +1,10 @@
+const cassandra = require('cassandra-driver');
+
+const client = new cassandra.Client({
+  contactPoints: ['127.0.0.1'],
+  keyspace: 'testyboi'
+})
+
+const insertData = async (dataArr) => {
+
+}

--- a/db/indexCass.js
+++ b/db/indexCass.js
@@ -2,7 +2,8 @@ const cassandra = require('cassandra-driver');
 
 const client = new cassandra.Client({
   contactPoints: ['127.0.0.1'],
-  keyspace: 'testyboi'
+  keyspace: 'testyboi',
+  localDataCenter: 'datacenter1'
 })
 
 module.exports.insertData = async (dataArr) => {
@@ -10,12 +11,10 @@ module.exports.insertData = async (dataArr) => {
     const queries = dataArr.map((entry) => {
       return {
         query: `INSERT INTO albumdata (albumID, comments) VALUES (?, ?)`,
-        params: [entry.albumId, JSON.stringify(entry.comments)]
+        params: [Number(entry.albumID), JSON.stringify(entry.comments)]
       }
     })
-
     const response = await client.batch(queries, {prepare: true});
-
     return response;
   } catch(e) {
     console.log('error in cassandra DB insert: ', e);

--- a/db/indexCass.js
+++ b/db/indexCass.js
@@ -6,5 +6,31 @@ const client = new cassandra.Client({
 })
 
 const insertData = async (dataArr) => {
+  try {
+    const queries = dataArr.map((entry) => {
+      return {
+        query: `INSERT INTO albumdata (albumID, comments) VALUES (?, ?)`,
+        params: [entry.albumId, JSON.stringify(entry.comments)]
+      }
+    })
 
+    const response = await client.batch(queries, {prepare: true});
+
+    return response;
+  } catch(e) {
+    console.log('error in cassandra DB insert: ', e);
+  }
 }
+
+/*
+const queries = [
+  {
+    query: 'UPDATE user_profiles SET email=? WHERE key=?',
+    params: [ emailAddress, 'hendrix' ]
+  },
+  {
+    query: 'INSERT INTO user_track (key, text, date) VALUES (?, ?, ?)',
+    params: [ 'hendrix', 'Changed email', new Date() ]
+  }
+];
+*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2837,6 +2837,21 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "cassandra-driver": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-4.0.0.tgz",
+      "integrity": "sha512-Mmj0+iHSe4LKowtybPcrUqt22UMK2I89TUb4iDi8v50lsg0ix6OFl2lkPBjyEC/iZJUP1B4xGYDsBuFA+PEUzw==",
+      "requires": {
+        "long": "^2.2.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+          "integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
+        }
+      }
+    },
     "caw": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "bson": "^4.0.2",
+    "cassandra-driver": "^4.0.0",
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "faker": "^4.1.0",


### PR DESCRIPTION
This code adds Cassandra database seeding as an option in the data generation script.

Now that I've determined optimal batch sizes for various save methods (`fs` vs. `postgres` vs. `cassandra`) and various entry quantities, I'm going to refactor the data generation script to calculate batch size automatically based on those variables, rather than require the user to supply batch size as an argument.

For now, Cassandra is considerably slower at DB insertion for 10M entries (~28 minutes, compared to postgresql's 8.5 minutes)