### PR TITLE
Move table creation query inside insert function

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -5,13 +5,14 @@ const pool = new pg.Pool({
   database: 'postgres'
 });
 
-const makeTableQuery = `CREATE TABLE IF NOT EXISTS albumdata (id SERIAL PRIMARY KEY, data JSON NOT NULL)`
-pool.query(makeTableQuery);
-
 module.exports.insertData = async (dataArr) => {
+
   try {
     const valuesArray = [];
     const paramsArray = [];
+
+    const makeTableQuery = `CREATE TABLE IF NOT EXISTS albumdata (id SERIAL PRIMARY KEY, data JSON NOT NULL)`
+    const makeTableResult = await pool.query(makeTableQuery);
 
     for (let i = 0; i < dataArr.length; i++) {
       valuesArray.push(`($${i+1})`);


### PR DESCRIPTION
Data generation for pg was not running the table maker on the first batch, so
only batches 2 through n were actually inserting data. Moving table creation
inside the insertion function (and adding 'await') fixes this problem