### PR TITLE
connect to remote ec2 db instead of local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 .aws.json
 jankData.json
 testData.json
+.env

--- a/db/index.js
+++ b/db/index.js
@@ -1,8 +1,11 @@
 const pg = require('pg');
+require('dotenv').config();
 const pool = new pg.Pool({
-  user: 'brox', // should be a superuser on your local postgres setup
-  host:'127.0.0.1',
-  database: 'postgres'
+  user: process.env.PG_EC2_USER, // should be a superuser on your local postgres setup
+  port: 5432,
+  password: process.env.PG_EC2_PW,
+  host: process.env.PG_EC2_HOST,
+  database: 'bandland'
 });
 
 module.exports.insertData = async (dataArr) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3734,6 +3734,11 @@
         "domelementtype": "1"
       }
     },
+    "dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
+    },
     "download": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/download/-/download-5.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bson": "^4.0.2",
     "cassandra-driver": "^4.0.0",
     "cors": "^2.8.5",
+    "dotenv": "^7.0.0",
     "express": "^4.16.4",
     "faker": "^4.1.0",
     "grunt": "^1.0.4",


### PR DESCRIPTION
PostgreSQL db is now deployed to an ec2 instance. This commit modifies the
connection properties in the db file to connect to this remote instance
rather than the local db. Process.env (and its associated npm module) has
been used to protect login info.